### PR TITLE
Refactor namespace methods to simplify API usage

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -25,13 +25,17 @@ type DeploymentAPI interface {
 // It provides high-level methods for retrieving and listing Namespaces with input
 // validation and pagination support. Unlike other resources, Namespaces are cluster-wide
 // objects and don't exist within other namespaces, so no namespace parameter is required
-// for listing operations. Methods support both label and field selector based filtering.
+// for listing operations. Methods return namespace names as strings rather than full
+// namespace objects. The interface supports retrieving individual namespaces by name
+// and listing namespaces using various filtering options including simple listing,
+// label-based filtering, and field-based filtering.
 type NamespaceAPI interface {
-	GetNamespaceByName(ctx context.Context, name string) (*corev1.Namespace, error)
+	GetNamespaceByName(ctx context.Context, name string) (string, error)
+	ListNamespaces(ctx context.Context, timeoutSeconds time.Duration, limit int64) ([]string, error)
 	ListNamespacesByLabel(ctx context.Context, labelSelector string, timeoutSeconds time.Duration,
-		limit int64) ([]corev1.Namespace, error)
+		limit int64) ([]string, error)
 	ListNamespacesByField(ctx context.Context, fieldSelector string, timeoutSeconds time.Duration,
-		limit int64) ([]corev1.Namespace, error)
+		limit int64) ([]string, error)
 }
 
 // ServiceAPI defines an interface for interacting with Kubernetes Services.

--- a/internal/api/namespace/namespace_test.go
+++ b/internal/api/namespace/namespace_test.go
@@ -123,21 +123,17 @@ func TestNamespaceAPI_GetNamespaceByName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			namespace, err := namespaceAPI.GetNamespaceByName(ctx, tt.namespaceName)
+			namespaceName, err := namespaceAPI.GetNamespaceByName(ctx, tt.namespaceName)
 
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
-				assert.Nil(t, namespace)
+				assert.Empty(t, namespaceName)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, namespace)
-				assert.Equal(t, tt.namespaceName, namespace.Name)
-				assert.Equal(t, corev1.NamespaceActive, namespace.Status.Phase)
-				assert.Equal(t, "test", namespace.Labels["env"])
-				assert.Equal(t, "service-a", namespace.Labels["app"])
+				assert.Equal(t, tt.namespaceName, namespaceName)
 			}
 		})
 	}
@@ -266,7 +262,7 @@ func TestNamespaceAPI_ListNamespacesByLabel(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := context.Background()
-			namespaces, err := namespaceAPI.ListNamespacesByLabel(ctx,
+			namespaceNames, err := namespaceAPI.ListNamespacesByLabel(ctx,
 				testCase.labelSelector,
 				testCase.timeoutSeconds,
 				testCase.limit,
@@ -279,17 +275,12 @@ func TestNamespaceAPI_ListNamespacesByLabel(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
-				assert.Len(t, namespaces, testCase.expectedCount)
+				assert.Len(t, namespaceNames, testCase.expectedCount)
 
 				// Check if all expected namespaces are present
 				if testCase.expectedCount > 0 {
-					foundNames := make([]string, len(namespaces))
-					for i, namespace := range namespaces {
-						foundNames[i] = namespace.Name
-					}
-
 					for _, expectedName := range testCase.expectedNames {
-						assert.Contains(t, foundNames, expectedName)
+						assert.Contains(t, namespaceNames, expectedName)
 					}
 				}
 			}
@@ -395,7 +386,7 @@ func TestNamespaceAPI_ListNamespacesByField(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			namespaces, err := namespaceAPI.ListNamespacesByField(ctx,
+			namespaceNames, err := namespaceAPI.ListNamespacesByField(ctx,
 				tt.fieldSelector,
 				tt.timeoutSeconds,
 				tt.limit,
@@ -406,14 +397,10 @@ func TestNamespaceAPI_ListNamespacesByField(t *testing.T) {
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
-				assert.Nil(t, namespaces)
+				assert.Nil(t, namespaceNames)
 			} else {
 				require.NoError(t, err)
-
-				// Note: The fake client doesn't properly support field selectors
-				// So we can't reliably test the number of results in this case
-				// However, we can at least verify we got a valid response
-				assert.NotNil(t, namespaces)
+				assert.NotNil(t, namespaceNames)
 			}
 		})
 	}


### PR DESCRIPTION
Refactored `NamespaceAPI` methods to return namespace names as strings rather than full `Namespace` objects, streamlining data handling. Added a new `ListNamespaces` function to retrieve all namespace names. Updated related tests and internal logic accordingly