### PR TITLE
Improve K8sClient validation and refactor namespace handling

### DIFF
--- a/k8s-client/k8s-client.go
+++ b/k8s-client/k8s-client.go
@@ -32,6 +32,20 @@ type K8sClient struct {
 
 type K8sClientOption func(*K8sClient) error
 
+func validateNilK8sClient(k8sClient *K8sClient) bool {
+	if k8sClient == nil {
+		return true
+	}
+
+	if k8sClient.pods == nil || k8sClient.services == nil ||
+		k8sClient.deployments == nil || k8sClient.namespaces == nil {
+
+		return true
+	}
+
+	return false
+}
+
 // WithKubeConfigLoader creates a K8sClientOption that configures the client to use
 // authentication via a kubeconfig file. This option requires a K8sAuthLoader implementation
 // that can load the kubeconfig data.
@@ -41,8 +55,7 @@ type K8sClientOption func(*K8sClient) error
 // configuration.
 func WithKubeConfigLoader(loader api.K8sAuthLoader) K8sClientOption {
 	return func(k8sClient *K8sClient) error {
-		err := val.ValidateStruct(k8sClient)
-		if err == nil {
+		if validateNilK8sClient(k8sClient) {
 			return ErrAlreadyConfigured
 		}
 
@@ -69,8 +82,7 @@ func WithKubeConfigLoader(loader api.K8sAuthLoader) K8sClientOption {
 // configuration.
 func WithServiceAccount() K8sClientOption {
 	return func(k8sClient *K8sClient) error {
-		err := val.ValidateStruct(k8sClient)
-		if err == nil {
+		if validateNilK8sClient(k8sClient) {
 			return ErrAlreadyConfigured
 		}
 


### PR DESCRIPTION
### Summary

This pull request introduces improvements in the `K8sClient` validation logic and refactors namespace-handling methods.

### Changes
- **Validation Helper**: Added `validateNilK8sClient` function to ensure `K8sClient` is properly initialized, improving clarity and reducing redundancy in `WithKubeConfigLoader` and `WithServiceAccount` functions.
- **Namespace Refactor**: Updated namespace-related methods to return namespace names as strings, replacing the previous structure of returning full Namespace objects. Added a `ListNamespaces` function to streamline namespace handling.

### Checklist

- [ ] Unit tests added/updated
- [ ] Documentation updated (if applicable) 
- [ ] Code changes match contributing guidelines