### PR TITLE
Fix client validation logic in Kubernetes configuration

### DIFF
--- a/k8s-client/k8s-client.go
+++ b/k8s-client/k8s-client.go
@@ -55,7 +55,7 @@ func validateNilK8sClient(k8sClient *K8sClient) bool {
 // configuration.
 func WithKubeConfigLoader(loader api.K8sAuthLoader) K8sClientOption {
 	return func(k8sClient *K8sClient) error {
-		if validateNilK8sClient(k8sClient) {
+		if !validateNilK8sClient(k8sClient) {
 			return ErrAlreadyConfigured
 		}
 
@@ -82,7 +82,7 @@ func WithKubeConfigLoader(loader api.K8sAuthLoader) K8sClientOption {
 // configuration.
 func WithServiceAccount() K8sClientOption {
 	return func(k8sClient *K8sClient) error {
-		if validateNilK8sClient(k8sClient) {
+		if !validateNilK8sClient(k8sClient) {
 			return ErrAlreadyConfigured
 		}
 


### PR DESCRIPTION
Corrected the conditional logic in `validateNilK8sClient` to ensure proper validation of Kubernetes client configurations. Prevents potential misconfigurations when using certain client options